### PR TITLE
Modify templates to truncate characters from labels

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
-version: 0.0.15
+version: 0.0.16
 appVersion: "0.0.11"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/

--- a/stable/cloudzero-cloudwatch-metrics/templates/_helpers.tpl
+++ b/stable/cloudzero-cloudwatch-metrics/templates/_helpers.tpl
@@ -41,7 +41,7 @@ helm.sh/chart: {{ include "cloudzero-cloudwatch-metrics.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-cloudzero.com/agent: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | replace "/" "-" | replace ":" "_" | quote }}
+cloudzero.com/agent: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | replace "/" "-" | replace ":" "_" | trunc -63 | quote }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This change was required as an issue was discovered through using a large image repository parameter. This caused the label for the pod to exceed the maximum amount of characters allowed (63).

## Description of the change

> Did something awesome w/out a breaking change.

## Type of change
- [x] Bug fix
- [ ] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
