### PR TITLE
Add the ability to configure imagePullSecrets

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
@@ -22,6 +22,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -30,3 +30,5 @@ annotations: {}
 priorityClassName:
 
 agentConfig: {}
+
+imagePullSecrets: []


### PR DESCRIPTION
## Description of the change

> Added the ability to configure imagePullSecrets on the daemonset. This is useful if images have to be pulled through private docker repos

## Type of change
- [ ] Bug fix
- [X] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
