### PR TITLE
Cto 438 k8s agent replicaset tracking option

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
-version: 0.0.21
+version: 0.0.22
 appVersion: "0.0.13"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/

--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
 version: 0.0.22
-appVersion: "0.0.13"
+appVersion: "0.0.14"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/
 icon: https://raw.githubusercontent.com/cloudzero/cloudzero-k8s-charts/docs/logo/cloudZerologo.png

--- a/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
@@ -52,6 +52,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CI_VERSION
           value: "k8s/1.3.0"
+        - name: TRACK_REPLICA_SETS
+          value: {{ .Values.trackReplicaSets | default "true" | quote }}
         # Please don't change the mountPath
         volumeMounts:
         - name: cwagentconfig

--- a/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
         - name: CI_VERSION
           value: "k8s/1.3.0"
         - name: TRACK_REPLICA_SETS
-          value: {{ .Values.trackReplicaSets | default "true" | quote }}
+          value: {{ printf "%v" .Values.trackReplicaSets | default true | quote }}
         # Please don't change the mountPath
         volumeMounts:
         - name: cwagentconfig

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -13,9 +13,13 @@ resources:
     cpu: 50m
     memory: 50Mi
 
+
+trackReplicaSets: "true"
+
 serviceAccount:
   create: true
   name:
+
   # For AWS ROSA (OpenShift)
   # add the annotations eks.amazonaws.com/role-arn:
   # this role allows the Pod to write to CloudWatch Logs to write metrics
@@ -26,7 +30,10 @@ hostNetwork: true
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+# Allow CloudZero agent to run on all nodes in case of a taint
+  - effect: NoSchedule
+    operator: Exists
 
 affinity: {}
 

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/cloudzero/cloudzero-agent
-  tag: 0.0.13
+  tag: 0.0.14
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name
@@ -12,7 +12,6 @@ resources:
   requests:
     cpu: 50m
     memory: 50Mi
-
 
 trackReplicaSets: "true"
 

--- a/test/k8s-cluster.k8s.local-1nodes.yaml
+++ b/test/k8s-cluster.k8s.local-1nodes.yaml
@@ -113,6 +113,9 @@ spec:
       type: Public
     masters: public
     nodes: public
+
+---
+
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:


### PR DESCRIPTION
## Description of the change

Made it optional to Track ReplicaSet back to there Deployments.  Setting the feature to true will track replicasets and consume more memory.

## Type of change
- [ ] Bug fix
- [ X] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ X] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
