### PR TITLE
Add `podSecurityContext` and `securityContext` value blocks

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
-version: 0.0.24
+version: 0.0.25
 appVersion: "0.0.16"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/

--- a/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
@@ -32,6 +32,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.podSecurityContext }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -55,6 +58,10 @@ spec:
         - name: TRACK_REPLICA_SETS
           value: {{ printf "%v" .Values.trackReplicaSets | default true | quote }}
         # Please don't change the mountPath
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: cwagentconfig
           mountPath: /etc/cwagentconfig

--- a/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.podSecurityContext }}
+      securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -64,3 +64,14 @@ daemonsetLabels: {}
 
 # For AWS ROSA (OpenShift)
 #openshift: true
+
+# Define the securityContext block for all containers in the pod
+# securityContext:
+#   k: v
+podSecurityContext: {}
+
+# Define the securityContext for the cloudzero-agent container.
+# pod:
+#   securityContext:
+#     k: v
+securityContext: {}


### PR DESCRIPTION
## Description of the change

Adds a `securityContext` and `podSecurityContext` block to the `cloudzero-cloudwatch-metrics` helm chart for clients that need this configuration.

Validated manually ala `helm template cz . --values ./values.yaml`

## Type of change
- [ ] Bug fix
- [x] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [x] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
