### PR TITLE
CP-14745: Decrease Log Frequency 

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 120
           }
         },
         "force_flush_interval": 5


### PR DESCRIPTION
## Description of the change

This change increases `metrics_collection_interval` to 2 minutes, which will decrease the number of logs produced by the Cloudwatch Agent. 


## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] cost savings

## Checklists

### Development
- [x] All changed code has 80% unit test coverage
- [x] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [x]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
