### PR TITLE
CP-14444: Bump Image Tag and App Versions for New Release

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
-version: 0.0.24
-appVersion: "0.0.16"
+version: 0.0.25
+appVersion: "0.0.17"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/
 icon: https://raw.githubusercontent.com/cloudzero/cloudzero-k8s-charts/docs/logo/cloudZerologo.png

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/cloudzero/cloudzero-agent
-  tag: 0.0.16
+  tag: 0.0.20
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name


### PR DESCRIPTION
## Description of the change

This PR bumps `cloudzero-cloudwatch-metrics` tag along with the chart's `appVersion` and `version`.

## Type of change
- [x] Bug fix
- [] New feature
