### PR TITLE
CP-15508: update cloudwatch agent chart to use the latest image version

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
 version: 0.0.25
-appVersion: "0.0.17"
+appVersion: "0.0.22"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/
 icon: https://raw.githubusercontent.com/cloudzero/cloudzero-k8s-charts/docs/logo/cloudZerologo.png

--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
-version: 0.0.25
+version: 0.0.26
 appVersion: "0.0.22"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/cloudzero/cloudzero-agent
-  tag: 0.0.20
+  tag: 0.0.22
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name


### PR DESCRIPTION
## Description of the change

Upgrading to v0.0.22 of the agent image to include latest CVE fixes

## Type of change
- [ ] Bug fix
- [ ] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
