### PR TITLE
Allow users to define the metrics collection interval

### DIFF
--- a/stable/cloudzero-cloudwatch-metrics/Chart.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudzero-cloudwatch-metrics
 description: A Helm chart to deploy cloudzero-cloudwatch-metrics project
-version: 0.0.26
+version: 0.0.27
 appVersion: "0.0.22"
 
 home: https://cloudzero.github.io/cloudzero-k8s-charts/

--- a/stable/cloudzero-cloudwatch-metrics/README.md
+++ b/stable/cloudzero-cloudwatch-metrics/README.md
@@ -43,4 +43,4 @@ helm upgrade --install cloudzero-cloudwatch-metrics           \
 | `nodeSelector` | Node labels for pod assignment | {} |
 | `tolerations` | Optional deployment tolerations | {} |
 | `annotations` | Optional pod annotations | {} |
-| `metricsCollectionInterval` | Metrics collection interval | 120 |
+| `metricsCollectionInterval` | Metrics collection interval in seconds | 120 |

--- a/stable/cloudzero-cloudwatch-metrics/README.md
+++ b/stable/cloudzero-cloudwatch-metrics/README.md
@@ -43,3 +43,4 @@ helm upgrade --install cloudzero-cloudwatch-metrics           \
 | `nodeSelector` | Node labels for pod assignment | {} |
 | `tolerations` | Optional deployment tolerations | {} |
 | `annotations` | Optional pod annotations | {} |
+| `metricsCollectionInterval` | Metrics collection interval | 120 |

--- a/stable/cloudzero-cloudwatch-metrics/README.md
+++ b/stable/cloudzero-cloudwatch-metrics/README.md
@@ -43,4 +43,4 @@ helm upgrade --install cloudzero-cloudwatch-metrics           \
 | `nodeSelector` | Node labels for pod assignment | {} |
 | `tolerations` | Optional deployment tolerations | {} |
 | `annotations` | Optional pod annotations | {} |
-| `metricsCollectionInterval` | Metrics collection interval in seconds | 120 |
+| `metricsCollectionInterval` | Metrics collection interval in seconds. It can be set to 5, 10, 15, 30, 45, 60 or 120 | 120 |

--- a/stable/cloudzero-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
-            "metrics_collection_interval": 120
+            "metrics_collection_interval": {{ .Values.metricsCollectionInterval }}
           }
         },
         "force_flush_interval": 5

--- a/stable/cloudzero-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/templates/configmap.yaml
@@ -14,7 +14,13 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
+            {{- $allowedIntervals := list 5 10 15 30 45 60 120 }}
+            {{- $failureMessage := printf "metricsCollectionInterval must be set to one of %s" (join "," $allowedIntervals) }}
+            {{- if not (has (int .Values.metricsCollectionInterval) $allowedIntervals) }}
+              {{- fail $failureMessage }}
+            {{- else }}
             "metrics_collection_interval": {{ .Values.metricsCollectionInterval }}
+            {{- end }}
           }
         },
         "force_flush_interval": 5

--- a/stable/cloudzero-cloudwatch-metrics/values.yaml
+++ b/stable/cloudzero-cloudwatch-metrics/values.yaml
@@ -64,3 +64,5 @@ daemonsetLabels: {}
 
 # For AWS ROSA (OpenShift)
 #openshift: true
+
+metricsCollectionInterval: 120


### PR DESCRIPTION
## Description of the change

> Allow users to define the metrics collection interval. The default value is still 120. 

## Type of change
- [ ] Bug fix
- [x] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
